### PR TITLE
Support for M2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vaimo/module-admin-auto-login",
     "type": "magento2-module",
     "require": {
-        "magento/framework": "100.*"
+        "magento/framework": "*"
     },
     "autoload": {
         "files": ["registration.php"],


### PR DESCRIPTION
By removing the require dependency for magento/framework on M2.1.x, we could have the module being used by the higher versions of Magento, such as M2.2, as well.