### PR TITLE
Keep URL parameters on redirect

### DIFF
--- a/App/Action/Plugin/Authentication.php
+++ b/App/Action/Plugin/Authentication.php
@@ -118,7 +118,7 @@ class Authentication
         }
 
         $resultRedirect = $this->resultRedirectFactory->create();
-        return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath));
+        return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath, $request->getParams()));
     }
 
     /**


### PR DESCRIPTION
Hi Rafael!
This is the minor fix for keeping URL parameters on redirect.
If you have turned off admin URL secret key and want to navigate to some page with URL parameters (for example: edit CMS page).