### PR TITLE
Disable password changing request if module is active

### DIFF
--- a/src/App/Action/Plugin/Authentication.php
+++ b/src/App/Action/Plugin/Authentication.php
@@ -141,27 +141,27 @@ class Authentication
         }
 
         $loginUserName = $this->getLoginUsername();
-        if (!empty($loginUserName)){
-            $this->autoLogin($request, $loginUserName);
 
-            if ($request instanceof \Magento\Framework\App\Request\Http) {
-                $routePath = sprintf(
-                    '%s/%s/%s',
-                    $request->getRouteName(),
-                    $request->getControllerName(),
-                    $request->getActionName()
-                );
-            } else {
-                $routePath = 'adminhtml/dashboard';
-            }
-
-            $resultRedirect = $this->resultRedirectFactory->create();
-            return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath, $request->getParams()));
-
-        } else {
+        if (empty($loginUserName)) {
             $this->messageManager->addErrorMessage("Create an admin user for Vaimo_AdminAutoLogin to work!");
             return $proceed($request);
         }
+
+        $this->autoLogin($request, $loginUserName);
+
+        if ($request instanceof \Magento\Framework\App\Request\Http) {
+            $routePath = sprintf(
+                '%s/%s/%s',
+                $request->getRouteName(),
+                $request->getControllerName(),
+                $request->getActionName()
+            );
+        } else {
+            $routePath = 'adminhtml/dashboard';
+        }
+
+        $resultRedirect = $this->resultRedirectFactory->create();
+        return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath, $request->getParams()));
     }
 
     /**

--- a/src/App/Action/Plugin/Authentication.php
+++ b/src/App/Action/Plugin/Authentication.php
@@ -50,6 +50,11 @@ class Authentication
     private $eventManager;
 
     /**
+     * @var \Magento\Framework\Message\ManagerInterface
+     */
+    private $messageManager;
+
+    /**
      * @var \Magento\Framework\Data\Collection\ModelFactory
      */
     private $modelFactory;
@@ -84,6 +89,7 @@ class Authentication
         \Magento\Backend\Model\Auth $auth,
         \Magento\Backend\Model\UrlInterface $backendUrl,
         \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\Data\Collection\ModelFactory $modelFactory,
         \Magento\Framework\Controller\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -92,6 +98,7 @@ class Authentication
         $this->auth = $auth;
         $this->backendUrl = $backendUrl;
         $this->eventManager = $eventManager;
+        $this->messageManager = $messageManager;
         $this->modelFactory = $modelFactory;
         $this->resultRedirectFactory = $resultRedirectFactory;
         $this->config = $scopeConfig;
@@ -133,21 +140,28 @@ class Authentication
             return $proceed($request);
         }
 
-        $this->autoLogin($request, $this->getLoginUsername());
+        $loginUserName = $this->getLoginUsername();
+        if (!empty($loginUserName)){
+            $this->autoLogin($request, $loginUserName);
 
-        if ($request instanceof \Magento\Framework\App\Request\Http) {
-            $routePath = sprintf(
-                '%s/%s/%s',
-                $request->getRouteName(),
-                $request->getControllerName(),
-                $request->getActionName()
-            );
+            if ($request instanceof \Magento\Framework\App\Request\Http) {
+                $routePath = sprintf(
+                    '%s/%s/%s',
+                    $request->getRouteName(),
+                    $request->getControllerName(),
+                    $request->getActionName()
+                );
+            } else {
+                $routePath = 'adminhtml/dashboard';
+            }
+
+            $resultRedirect = $this->resultRedirectFactory->create();
+            return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath, $request->getParams()));
+
         } else {
-            $routePath = 'adminhtml/dashboard';
+            $this->messageManager->addErrorMessage("Create an admin user for Vaimo_AdminAutoLogin to work!");
+            return $proceed($request);
         }
-
-        $resultRedirect = $this->resultRedirectFactory->create();
-        return $resultRedirect->setUrl($this->backendUrl->getUrl($routePath, $request->getParams()));
     }
 
     /**
@@ -171,10 +185,6 @@ class Authentication
         }
 
         $username = reset($usernameList);
-
-        if (empty($username)) {
-            throw new \Exception('There are no admin users to attempt login to.');
-        }
 
         return $username;
     }

--- a/src/App/Action/Plugin/DisablePasswordChangeRequest.php
+++ b/src/App/Action/Plugin/DisablePasswordChangeRequest.php
@@ -10,7 +10,6 @@ namespace Vaimo\AdminAutoLogin\App\Action\Plugin;
  */
 class DisablePasswordChangeRequest
 {
-
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */

--- a/src/App/Action/Plugin/DisablePasswordChangeRequest.php
+++ b/src/App/Action/Plugin/DisablePasswordChangeRequest.php
@@ -16,7 +16,6 @@ class DisablePasswordChangeRequest
      */
     private $config;
 
-
     /**
      * DisablePasswordChangeRequest constructor.
      *
@@ -28,7 +27,6 @@ class DisablePasswordChangeRequest
         $this->config = $scopeConfig;
     }
 
-
     /**
      * @param \Magento\User\Model\Backend\Config\ObserverConfig $subject
      * @param \Closure $proceed
@@ -36,7 +34,6 @@ class DisablePasswordChangeRequest
      */
     public function aroundGetAdminPasswordLifetime(\Magento\User\Model\Backend\Config\ObserverConfig $subject, $proceed)
     {
-
         // If admin_auto_login_module is inactive, get password lifetime normally.
         if (!$this->config->isSetFlag('admin/admin_auto_login/active')) {
             return $proceed();
@@ -47,7 +44,6 @@ class DisablePasswordChangeRequest
         return 86400 * 365 * 50;
     }
 
-
     /**
      * @param \Magento\User\Model\Backend\Config\ObserverConfig $subject
      * @param \Closure $proceed
@@ -55,7 +51,6 @@ class DisablePasswordChangeRequest
      */
     public function aroundIsPasswordChangeForced(\Magento\User\Model\Backend\Config\ObserverConfig $subject, $proceed)
     {
-
         if (!$this->config->isSetFlag('admin/admin_auto_login/active')) {
             return $proceed();
         }
@@ -64,7 +59,3 @@ class DisablePasswordChangeRequest
     }
 
 }
-
-
-
-

--- a/src/App/Action/Plugin/DisablePasswordChangeRequest.php
+++ b/src/App/Action/Plugin/DisablePasswordChangeRequest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Vaimo Group. All rights reserved.
+ * See LICENSE for license details.
+ */
+namespace Vaimo\AdminAutoLogin\App\Action\Plugin;
+
+/**
+ * @plugin \Magento\User\Model\Backend\Config\ObserverConfig
+ */
+class DisablePasswordChangeRequest
+{
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $config;
+
+
+    /**
+     * DisablePasswordChangeRequest constructor.
+     *
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+    ) {
+        $this->config = $scopeConfig;
+    }
+
+
+    /**
+     * @param \Magento\User\Model\Backend\Config\ObserverConfig $subject
+     * @param \Closure $proceed
+     * @return int
+     */
+    public function aroundGetAdminPasswordLifetime(\Magento\User\Model\Backend\Config\ObserverConfig $subject, $proceed)
+    {
+
+        // If admin_auto_login_module is inactive, get password lifetime normally.
+        if (!$this->config->isSetFlag('admin/admin_auto_login/active')) {
+            return $proceed();
+        }
+
+        // Otherwise password lifetime is infinitive.
+        // Could return INF, but to avoid unexpected side effects, let's return 50 years.
+        return 86400 * 365 * 50;
+    }
+
+
+    /**
+     * @param \Magento\User\Model\Backend\Config\ObserverConfig $subject
+     * @param \Closure $proceed
+     * @return bool
+     */
+    public function aroundIsPasswordChangeForced(\Magento\User\Model\Backend\Config\ObserverConfig $subject, $proceed)
+    {
+
+        if (!$this->config->isSetFlag('admin/admin_auto_login/active')) {
+            return $proceed();
+        }
+
+        return false;
+    }
+
+}
+
+
+
+

--- a/src/App/Action/Plugin/DisablePasswordChangeRequest.php
+++ b/src/App/Action/Plugin/DisablePasswordChangeRequest.php
@@ -56,5 +56,4 @@ class DisablePasswordChangeRequest
 
         return false;
     }
-
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Vaimo Group. All rights reserved.
+ * See LICENSE for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
+    <type name="Magento\User\Model\Backend\Config\ObserverConfig">
+        <plugin name="vaimo_admin_auto_login_plugin_disable_password_change_request"
+                type="Vaimo\AdminAutoLogin\App\Action\Plugin\DisablePasswordChangeRequest"
+                sortOrder="10"
+                disabled="false"/>
+    </type>
+</config>
+


### PR DESCRIPTION
https://github.com/vaimo/module-admin-auto-login/issues/9

Sorry If my solution is hacky, I took a look at:

\Magento\Security\Model\PasswordResetRequestEvent,
\Magento\Security\Model\Config and
\Magento\Security\Model\SecurityManager

but had no luck. Then decided to just change the password lifetime and play it safe with also disabling forcing password change.

Only changes are to 
src/App/Action/Plugin/DisablePasswordChangeRequest.php
src/etc/di.xml
But this request is also built on top of the last ones so just ignore other differences.