### PR TITLE
Refactoring App/Action/Plugin/Authentication.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed 
+
+- Dropped support for Magento 2.0
 
 ## [1.4.5] - 2022-06-02
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "license": "Apache-2.0",
     "require": {
-        "magento/framework": "100.* | 101.* | 102.* | 103.*"
+        "magento/framework": "100.1.* | 101.* | 102.* | 103.*"
     },
     "keywords": [
         "admin",

--- a/src/App/Action/Plugin/Authentication.php
+++ b/src/App/Action/Plugin/Authentication.php
@@ -13,10 +13,8 @@ use function sprintf;
 use function array_keys;
 use function reset;
 
-
 class Authentication
 {
-
     /**
      * Default usernames to attempt login if there is no configuration
      */
@@ -193,7 +191,6 @@ class Authentication
         }
 
         $username = reset($usernameList);
-
         return $username;
     }
 

--- a/src/App/Action/Plugin/Authentication.php
+++ b/src/App/Action/Plugin/Authentication.php
@@ -283,10 +283,6 @@ class Authentication
         }
     }
 
-    /**
-     * Prolong session for M2.1+
-     * Intentional usage of Object Manager, since the class is not available on M2.0 and will throw an exception.
-     */
     private function prolongSession()
     {
         $this->adminSessionsManager->processLogin();


### PR DESCRIPTION
Why: 
- Functions prolongSession() and populateAdminUserSessionTable() used object manager directly.
- populateAdminUserSessionTable() called afterLogin() function of a Plugin
- Messy, hard to read and harder approach.

Fixes:
- Used constructor and magento's default di to fetch objects.
- Instead of calling the afterLogin() function, implemented functionality in 3 lines (copy paste)

Small things:
- Removed 'jambi' from default usernames
- Code cleanup.