### PR TITLE
FIPRO-37 Refactor AdminUser Class

### DIFF
--- a/src/App/Action/Plugin/Authentication.php
+++ b/src/App/Action/Plugin/Authentication.php
@@ -69,9 +69,9 @@ class Authentication
     private $config;
 
     /**
-     * @var \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUser
+     * @var \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUsernameList
      */
-    private $adminUserSource;
+    private $adminUsernameList;
 
     /**
      * @var AdminSessionsManager
@@ -86,19 +86,19 @@ class Authentication
      * @param \Magento\Framework\Data\Collection\ModelFactory $modelFactory
      * @param \Magento\Framework\Controller\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUser $adminUserSource
+     * @param \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUsernameList $adminUsernameList
      * @param AdminSessionsManager $adminSessionsManager
      */
     public function __construct(
-        \Magento\Backend\Model\Auth $auth,
-        \Magento\Backend\Model\UrlInterface $backendUrl,
-        \Magento\Framework\Event\ManagerInterface $eventManager,
-        \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Magento\Framework\Data\Collection\ModelFactory $modelFactory,
-        \Magento\Framework\Controller\Result\RedirectFactory $resultRedirectFactory,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUser $adminUserSource,
-        \Magento\Security\Model\AdminSessionsManager $adminSessionsManager
+        \Magento\Backend\Model\Auth                                 $auth,
+        \Magento\Backend\Model\UrlInterface                         $backendUrl,
+        \Magento\Framework\Event\ManagerInterface                   $eventManager,
+        \Magento\Framework\Message\ManagerInterface                 $messageManager,
+        \Magento\Framework\Data\Collection\ModelFactory             $modelFactory,
+        \Magento\Framework\Controller\Result\RedirectFactory        $resultRedirectFactory,
+        \Magento\Framework\App\Config\ScopeConfigInterface          $scopeConfig,
+        \Vaimo\AdminAutoLogin\Model\Config\Source\AdminUsernameList $adminUsernameList,
+        \Magento\Security\Model\AdminSessionsManager                $adminSessionsManager
     ) {
         $this->auth = $auth;
         $this->backendUrl = $backendUrl;
@@ -107,7 +107,7 @@ class Authentication
         $this->modelFactory = $modelFactory;
         $this->resultRedirectFactory = $resultRedirectFactory;
         $this->config = $scopeConfig;
-        $this->adminUserSource = $adminUserSource;
+        $this->adminUsernameList = $adminUsernameList;
         $this->adminSessionsManager = $adminSessionsManager;
     }
 
@@ -182,7 +182,7 @@ class Authentication
             return $username;
         }
 
-        $usernameList = array_keys($this->adminUserSource->toArray(false));
+        $usernameList = array_keys($this->adminUsernameList->get(false));
 
         foreach (self::DEFAULT_USERNAMES as $username) {
             if (in_array($username, $usernameList, true)) {

--- a/src/Model/Config/Source/AdminUsernameList.php
+++ b/src/Model/Config/Source/AdminUsernameList.php
@@ -5,11 +5,8 @@
  */
 namespace Vaimo\AdminAutoLogin\Model\Config\Source;
 
-use function __;
-
-class AdminUser implements \Magento\Framework\Option\ArrayInterface
+class AdminUsernameList
 {
-
     /**
      * @var \Magento\User\Model\ResourceModel\User\Collection
      */
@@ -21,12 +18,13 @@ class AdminUser implements \Magento\Framework\Option\ArrayInterface
     private $users;
 
     /**
-     * AdminUser constructor.
+     * AdminUsernameList constructor.
      *
      * @param \Magento\User\Model\ResourceModel\User\Collection $userCollection
      */
-    public function __construct(\Magento\User\Model\ResourceModel\User\Collection $userCollection)
-    {
+    public function __construct(
+        \Magento\User\Model\ResourceModel\User\Collection $userCollection
+    ) {
         $this->userCollection = $userCollection;
     }
 
@@ -36,7 +34,7 @@ class AdminUser implements \Magento\Framework\Option\ArrayInterface
      * @param bool $includeEmptyChoice
      * @return array
      */
-    public function toArray($includeEmptyChoice = true)
+    public function get($includeEmptyChoice = true)
     {
         if ($this->users === null) {
             $this->users = [];
@@ -54,22 +52,6 @@ class AdminUser implements \Magento\Framework\Option\ArrayInterface
         }
 
         return $this->users;
-    }
-
-    /**
-     * Options getter
-     *
-     * @return array
-     */
-    public function toOptionArray()
-    {
-        $users = [];
-
-        foreach ($this->toArray() as $value => $label) {
-            $users[] = ['value' => $value, 'label' => $label];
-        }
-
-        return $users;
     }
 
 }


### PR DESCRIPTION
Refactored Vaimo\AdminAutoLogin\Model\Config\Source\AdminUser.php

Changes:
- Renamed the class and toArray() methods
- Refactored to not implement \Magento\Framework\Option\ArrayInterface
- Removed toOptionArray() method
- Cleaned code

Why:
- The Class is only used to get a list of admin usernames. New naming makes the single purpose of the class more clear
- Inheritance of \Magento\Framework\Option\ArrayInterface is redundant
- toOptionArray() is not used anywhere
- Easier to test